### PR TITLE
Allow non-hash data

### DIFF
--- a/lib/ruby-handlebars.rb
+++ b/lib/ruby-handlebars.rb
@@ -10,6 +10,7 @@ module Handlebars
     def initialize
       @helpers = {}
       @partials = {}
+      @locals = {}
       register_default_helpers
     end
 

--- a/lib/ruby-handlebars/context.rb
+++ b/lib/ruby-handlebars/context.rb
@@ -29,10 +29,6 @@ module Handlebars
         end
       end
 
-      if item.instance_variables.include?("@#{attribute}")
-        return item.instance_variable_get("@#{attribute}")
-      end
-
       if item.respond_to?(sym_attr)
         return item.send(sym_attr)
       end

--- a/lib/ruby-handlebars/context.rb
+++ b/lib/ruby-handlebars/context.rb
@@ -25,7 +25,7 @@ module Handlebars
       sym_attr = attribute.to_sym
       str_attr = attribute.to_s
 
-      if item.respond_to?(:[])
+      if item.respond_to?(:[]) && item.respond_to?(:has_key?)
         if item.has_key?(sym_attr)
           return item[sym_attr]
         elsif item.has_key?(str_attr)

--- a/lib/ruby-handlebars/context.rb
+++ b/lib/ruby-handlebars/context.rb
@@ -3,7 +3,11 @@ module Handlebars
     def get(path)
       items = path.split('.'.freeze)
 
-      current = @data
+      if @locals.key? items.first.to_sym
+        current = @locals
+      else
+        current = @data
+      end
       until items.empty?
         current = get_attribute(current, items.shift)
       end
@@ -12,7 +16,7 @@ module Handlebars
     end
 
     def add_item(key, value)
-      @data[key] = value
+      @locals[key.to_sym] = value
     end
 
     private

--- a/lib/ruby-handlebars/template.rb
+++ b/lib/ruby-handlebars/template.rb
@@ -7,8 +7,8 @@ module Handlebars
       @ast = ast
     end
 
-    def call(args)
-      if args.is_a? Hash
+    def call(args = nil)
+      if args
         @hbs.set_context(args)
       end
 

--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -52,7 +52,7 @@ module Handlebars
 
     class Partial < TreeItem.new(:partial_name)
       def _eval(context)
-        context.get_partial(partial_name.to_s).call(context)
+        context.get_partial(partial_name.to_s).call
       end
     end
 

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -21,6 +21,14 @@ describe Handlebars::Handlebars do
       expect(evaluate('Hello {{name}}', double(name: 'world'))).to eq('Hello world')
     end
 
+    it 'prefers hash value over method value' do
+      expect(evaluate('Hello {{name}}', double(name: 'world', '[]': 'dog', has_key?: true))).to eq('Hello dog')
+    end
+
+    it 'handles object that implement #[] but not #has_key?' do
+      expect(evaluate('Hello {{name}}', double(name: 'world', '[]': 'dog'))).to eq('Hello world')
+    end
+
     it 'a replacement with a path' do
       expect(evaluate('My simple template: {{person.name}}', {person: {name: 'Another name'}})).to eq('My simple template: Another name')
     end

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -17,6 +17,10 @@ describe Handlebars::Handlebars do
       expect(evaluate('Hello {{name}}', {name: 'world'})).to eq('Hello world')
     end
 
+    it 'allows values specified by methods' do
+      expect(evaluate('Hello {{name}}', double(name: 'world'))).to eq('Hello world')
+    end
+
     it 'a replacement with a path' do
       expect(evaluate('My simple template: {{person.name}}', {person: {name: 'Another name'}})).to eq('My simple template: Another name')
     end

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -205,6 +205,29 @@ describe Handlebars::Handlebars do
           ].join("\n"))
         end
 
+        it 'works with non-hash data' do
+          template = [
+            "<ul>",
+            "{{#each items}}  <li>{{this.name}}</li>",
+            "{{/each}}</ul>"
+          ].join("\n")
+
+          data = double(items: ducks)
+          expect(evaluate(template, data)).to eq([
+            "<ul>",
+            "  <li>Huey</li>",
+            "  <li>Dewey</li>",
+            "  <li>Louis</li>",
+            "</ul>"
+          ].join("\n"))
+
+          data = {items: []}
+          expect(evaluate(template, data)).to eq([
+            "<ul>",
+            "</ul>"
+          ].join("\n"))
+        end
+
         it 'using an else statement' do
           template = [
             "<ul>",


### PR DESCRIPTION
Handlebars.js allows passing any object that implements methods that correspond to the requested value keys. This pull request aims to implement similar ability by:

* Allowing any object passed as data to `Template#call`
* Not storing values like `this` on the data object
* Carefully checking that both `#[]` and `#has_key?` are implemented before using them