### PR TITLE
Drop unused 'colorize' dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'parslet', '~> 1.6', '>= 1.6.2'
-gem 'colorize', '~> 0.7', '>= 0.7.5'
 
 group :development do
   gem 'pry', '~> 0.10', '>= 0.10.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,6 @@ GEM
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.2)
-    colorize (0.8.1)
     debug_inspector (0.0.3)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -90,7 +89,6 @@ PLATFORMS
 
 DEPENDENCIES
   codeclimate-test-reporter (~> 0.4, >= 0.4.6)
-  colorize (~> 0.7, >= 0.7.5)
   jeweler (~> 2.0, >= 2.0.1)
   parslet (~> 1.6, >= 1.6.2)
   pry (~> 0.10, >= 0.10.1)
@@ -99,4 +97,4 @@ DEPENDENCIES
   rspec-mocks (~> 3.1, >= 3.1.3)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/lib/ruby-handlebars/tree.rb
+++ b/lib/ruby-handlebars/tree.rb
@@ -1,5 +1,3 @@
-require 'colorize'
-
 module Handlebars
   module Tree
     class TreeItem < Struct

--- a/ruby-handlebars.gemspec
+++ b/ruby-handlebars.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Vincent Pretre".freeze, "Hiptest R&D".freeze]
-  s.date = "2018-02-12"
+  s.date = "2019-06-20"
   s.email = "v.pretre@hiptest.net".freeze
   s.extra_rdoc_files = [
     "LICENSE",
@@ -26,40 +26,37 @@ Gem::Specification.new do |s|
     "lib/ruby-handlebars/tree.rb"
   ]
   s.homepage = "https://github.com/vincent-psarga/ruby-handlebars".freeze
-  s.rubygems_version = "2.6.10".freeze
+  s.rubygems_version = "3.0.3".freeze
   s.summary = "Pure Ruby library for Handlebars templates".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<parslet>.freeze, [">= 1.6.2", "~> 1.6"])
-      s.add_runtime_dependency(%q<colorize>.freeze, [">= 0.7.5", "~> 0.7"])
-      s.add_development_dependency(%q<pry>.freeze, [">= 0.10.1", "~> 0.10"])
-      s.add_development_dependency(%q<pry-stack_explorer>.freeze, [">= 0.4.9.1", "~> 0.4"])
+      s.add_runtime_dependency(%q<parslet>.freeze, ["~> 1.6", ">= 1.6.2"])
+      s.add_development_dependency(%q<pry>.freeze, ["~> 0.10", ">= 0.10.1"])
+      s.add_development_dependency(%q<pry-stack_explorer>.freeze, ["~> 0.4", ">= 0.4.9.1"])
       s.add_development_dependency(%q<rspec>.freeze, [">= 3.1.0", "~> 3.1"])
-      s.add_development_dependency(%q<rspec-mocks>.freeze, [">= 3.1.3", "~> 3.1"])
-      s.add_development_dependency(%q<codeclimate-test-reporter>.freeze, [">= 0.4.6", "~> 0.4"])
-      s.add_development_dependency(%q<jeweler>.freeze, [">= 2.0.1", "~> 2.0"])
+      s.add_development_dependency(%q<rspec-mocks>.freeze, ["~> 3.1", ">= 3.1.3"])
+      s.add_development_dependency(%q<codeclimate-test-reporter>.freeze, ["~> 0.4", ">= 0.4.6"])
+      s.add_development_dependency(%q<jeweler>.freeze, ["~> 2.0", ">= 2.0.1"])
     else
-      s.add_dependency(%q<parslet>.freeze, [">= 1.6.2", "~> 1.6"])
-      s.add_dependency(%q<colorize>.freeze, [">= 0.7.5", "~> 0.7"])
-      s.add_dependency(%q<pry>.freeze, [">= 0.10.1", "~> 0.10"])
-      s.add_dependency(%q<pry-stack_explorer>.freeze, [">= 0.4.9.1", "~> 0.4"])
+      s.add_dependency(%q<parslet>.freeze, ["~> 1.6", ">= 1.6.2"])
+      s.add_dependency(%q<pry>.freeze, ["~> 0.10", ">= 0.10.1"])
+      s.add_dependency(%q<pry-stack_explorer>.freeze, ["~> 0.4", ">= 0.4.9.1"])
       s.add_dependency(%q<rspec>.freeze, [">= 3.1.0", "~> 3.1"])
-      s.add_dependency(%q<rspec-mocks>.freeze, [">= 3.1.3", "~> 3.1"])
-      s.add_dependency(%q<codeclimate-test-reporter>.freeze, [">= 0.4.6", "~> 0.4"])
-      s.add_dependency(%q<jeweler>.freeze, [">= 2.0.1", "~> 2.0"])
+      s.add_dependency(%q<rspec-mocks>.freeze, ["~> 3.1", ">= 3.1.3"])
+      s.add_dependency(%q<codeclimate-test-reporter>.freeze, ["~> 0.4", ">= 0.4.6"])
+      s.add_dependency(%q<jeweler>.freeze, ["~> 2.0", ">= 2.0.1"])
     end
   else
-    s.add_dependency(%q<parslet>.freeze, [">= 1.6.2", "~> 1.6"])
-    s.add_dependency(%q<colorize>.freeze, [">= 0.7.5", "~> 0.7"])
-    s.add_dependency(%q<pry>.freeze, [">= 0.10.1", "~> 0.10"])
-    s.add_dependency(%q<pry-stack_explorer>.freeze, [">= 0.4.9.1", "~> 0.4"])
+    s.add_dependency(%q<parslet>.freeze, ["~> 1.6", ">= 1.6.2"])
+    s.add_dependency(%q<pry>.freeze, ["~> 0.10", ">= 0.10.1"])
+    s.add_dependency(%q<pry-stack_explorer>.freeze, ["~> 0.4", ">= 0.4.9.1"])
     s.add_dependency(%q<rspec>.freeze, [">= 3.1.0", "~> 3.1"])
-    s.add_dependency(%q<rspec-mocks>.freeze, [">= 3.1.3", "~> 3.1"])
-    s.add_dependency(%q<codeclimate-test-reporter>.freeze, [">= 0.4.6", "~> 0.4"])
-    s.add_dependency(%q<jeweler>.freeze, [">= 2.0.1", "~> 2.0"])
+    s.add_dependency(%q<rspec-mocks>.freeze, ["~> 3.1", ">= 3.1.3"])
+    s.add_dependency(%q<codeclimate-test-reporter>.freeze, ["~> 0.4", ">= 0.4.6"])
+    s.add_dependency(%q<jeweler>.freeze, ["~> 2.0", ">= 2.0.1"])
   end
 end
 


### PR DESCRIPTION
The colorize gem is licensed under the GPL so cannot be used in an MIT-licensed project. Also, it's not used.